### PR TITLE
Feature/elbow content

### DIFF
--- a/src/less/lcars-buttons.less
+++ b/src/less/lcars-buttons.less
@@ -1,8 +1,8 @@
 .lcars-stack-vertical .lcars-button {
-    width: 100%;
+    width: 100.5%;
     height: 1.8em;
 
-    border-top: 3px solid;
+    border-bottom: 3px solid;
     border-color: @background;
 }
 
@@ -14,7 +14,7 @@
         padding-left: 1em;
         padding-right: 1em;
 
-        border-@{margin-side}: 3px solid;
+        border-@{margin-side}: @column-padding-vertical solid;
         border-color: @background;
     }
 }

--- a/src/less/lcars-columns.less
+++ b/src/less/lcars-columns.less
@@ -23,16 +23,38 @@
 
         overflow: hidden;
 
+        border-top: @column-padding-vertical solid;
+        border-bottom: @column-padding-vertical solid;
+        border-color: @background;
+
         //HACK: When pixel height == 100% of parent height, things break. Since window cannot ever be ~.1 units high, this fixes that!
-        height: calc(~"100% - " unit(@elbow-height * @shoulderCount + 0.1, px));
+        height: calc(~"100% - " unit(@elbow-height * @shoulderCount + 0.1 + (2 * @column-padding-vertical), px));
         min-height: 0;
+
+        .lcars-column-filler() {
+            &:before {
+                content: "";
+
+                float: left;
+                clear: both;
+                position: absolute;
+
+                width: 100% - @elbow-cutout-width;
+                height: 100%;
+
+                background-color: cornflowerblue;
+            }
+        }
 
         .lcars-left > & {
             padding-right: @elbow-cutout-width;
+            float: left;
+
+            .lcars-column-filler();
         }
 
         .lcars-center > & {
-            height: calc(~"100% - " unit(@center-elbow-height * @shoulderCount, px));
+            height: calc(~"100% - " unit(@center-elbow-height * @shoulderCount + (2 * @column-padding-vertical), px));
             min-height: @elbow-height * @shoulderCount - @center-elbow-height * @shoulderCount;
 
             width: 100%;
@@ -41,6 +63,8 @@
         .lcars-right > & {
             padding-left: @elbow-cutout-width;
             float: right;
+
+            .lcars-column-filler();
         }
     }
 }

--- a/src/less/lcars-variables.less
+++ b/src/less/lcars-variables.less
@@ -14,6 +14,7 @@
 //Column settings
 @column-padding-left: 0.125%;
 @column-padding-right: 0.125%;
+@column-padding-vertical: 3px;
 
 //Amount of variance in luminance between different members of the same group
 @group-min-luminance: 0.6;


### PR DESCRIPTION
Added fillers for left and right elbows (an element which sits underneath content and fills in empty space).

One slight hax here:
- buttons now have 100.5% width in vertical stack views. This prevents half pixel errors from showing very thin bands of colour (bad browser, fix your sub pixel precision!)
